### PR TITLE
Add basic typing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+yarn.lock

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,64 +2,64 @@ import { Options as HTMLMinifierOptions } from "html-minifier";
 import { Options as CleanCSSOptions } from "clean-css";
 import { CompressOptions } from "terser";
 
-declare module "lotek" {
-  type Group = {
-    name?: string;
-    debug_mode?: boolean;
+type Group = {
+  name?: string;
+  debug_mode?: boolean;
 
-    /**
-     * @description configuration for JS file
-     */
-    js?: {
-      files?: string[];
-      output?: string;
-      use_closure_per_file?: boolean;
-      use_closure_all?: boolean;
-      minify?: boolean;
-      minify_options?: CompressOptions;
-      [k: string]: any;
-    };
-
-    /**
-     * @description configuration for css file
-     */
-    css?: {
-      files?: string[];
-      output?: string;
-      url_replaces?: {
-        find: string;
-        replacement: string;
-      }[];
-      replace_log_output?: string;
-      minify?: boolean;
-      minify_options?: CleanCSSOptions;
-      [k: string]: any;
-    };
-
-    /**
-     * @description configuration for HTML file
-     */
-    html?: {
-      files?: string[];
-      output?: string;
-      replaces?: {
-        find: string;
-        replacement: string;
-      }[];
-      minify?: boolean;
-      minify_options?: HTMLMinifierOptions;
-      [k: string]: any;
-    };
+  /**
+   * @description configuration for JS file
+   */
+  js?: {
+    files?: string[];
+    output?: string;
+    use_closure_per_file?: boolean;
+    use_closure_all?: boolean;
+    minify?: boolean;
+    minify_options?: CompressOptions;
     [k: string]: any;
   };
 
-  type LotekConfig = {
-    groups: Group[];
+  /**
+   * @description configuration for css file
+   */
+  css?: {
+    files?: string[];
+    output?: string;
+    url_replaces?: {
+      find: string;
+      replacement: string;
+    }[];
+    replace_log_output?: string;
+    minify?: boolean;
+    minify_options?: CleanCSSOptions;
     [k: string]: any;
   };
 
-  export class Lotek {
-    constructor(config: LotekConfig);
-    compile(): Promise<unknown>;
-  }
+  /**
+   * @description configuration for HTML file
+   */
+  html?: {
+    files?: string[];
+    output?: string;
+    replaces?: {
+      find: string;
+      replacement: string;
+    }[];
+    minify?: boolean;
+    minify_options?: HTMLMinifierOptions;
+    [k: string]: any;
+  };
+  [k: string]: any;
+};
+
+type LotekConfig = {
+  groups: Group[];
+  [k: string]: any;
+};
+
+declare class Lotek {
+  constructor(config: LotekConfig);
+  compile(): Promise<unknown>;
 }
+
+export = Lotek;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,57 @@
+import { Options as HTMLMinifierOptions } from "html-minifier";
+import { Options as CleanCSSOptions } from "clean-css";
+import { CompressOptions } from "terser";
+
+declare module "lotek" {
+  type Group = {
+    name?: string;
+    debug_mode?: boolean;
+    js?: {
+      files?: string[];
+      output?: string;
+      use_closure_per_file?: boolean;
+      use_closure_all?: boolean;
+      minify?: boolean;
+      minify_options?: CompressOptions;
+      [k: string]: any;
+    };
+    css?: {
+      files?: string[];
+      output?: string;
+      url_replaces?: {
+        find: string;
+        replacement: string;
+      }[];
+      replace_log_output?: string;
+      minify?: boolean;
+      minify_options?: CleanCSSOptions;
+      [k: string]: any;
+    };
+
+    /**
+     * configuration for HTML file
+     */
+    html?: {
+      files?: string[];
+      output?: string;
+      replaces?: {
+        find: string;
+        replacement: string;
+      }[];
+      minify?: boolean;
+      minify_options?: HTMLMinifierOptions;
+      [k: string]: any;
+    };
+    [k: string]: any;
+  };
+
+  type LotekConfig = {
+    groups: Group[];
+    [k: string]: any;
+  };
+
+  export class Lotek {
+    constructor(config: LotekConfig);
+    compile(): Promise<unknown>;
+  }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,10 @@ declare module "lotek" {
   type Group = {
     name?: string;
     debug_mode?: boolean;
+
+    /**
+     * @description configuration for JS file
+     */
     js?: {
       files?: string[];
       output?: string;
@@ -15,6 +19,10 @@ declare module "lotek" {
       minify_options?: CompressOptions;
       [k: string]: any;
     };
+
+    /**
+     * @description configuration for css file
+     */
     css?: {
       files?: string[];
       output?: string;
@@ -29,7 +37,7 @@ declare module "lotek" {
     };
 
     /**
-     * configuration for HTML file
+     * @description configuration for HTML file
      */
     html?: {
       files?: string[];

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
   },
   "homepage": "https://github.com/gaibz/Lotek#readme",
   "dependencies": {
+    "@types/clean-css": "^4.2.2",
+    "@types/html-minifier": "^4.0.0",
+    "@types/terser": "^3.12.0",
     "clean-css": "^4.2.3",
     "html-minifier": "^4.0.0",
     "terser": "^5.3.1"


### PR DESCRIPTION
Add basic typing for index.js. very useful for vscode's intellisense suggestion when passing config object directly when instantiating Lotek class. But i'm not sure if the typing is already covers all available field, since i only define the type based on example in readme usage section. need feedback on that. nice package btw.

nb: `esModuleInterop` flag should be set to be `true` when using it with es6 import syntax.